### PR TITLE
Set STS'initiallevel to feasible value in valid-v860

### DIFF
--- a/valid-v860/tests-ST-storage/input/st-storage/clusters/area 2/list.ini
+++ b/valid-v860/tests-ST-storage/input/st-storage/clusters/area 2/list.ini
@@ -2,7 +2,7 @@
 injectionnominalcapacity = 150.000000
 withdrawalnominalcapacity = 100.000000
 reservoircapacity = 500.000000
-initiallevel = 0.100000
+initiallevel = 0.4
 efficiency = 0.900000
 name = my-sts-2
 initialleveloptim = false


### PR DESCRIPTION
`initiallevel=0.1` was too steep WRT rule curves (`low=0.4` and `up=1.0` respectively)