### PR TITLE
Update checkout action (v4 -> v6)

### DIFF
--- a/.github/workflows/generate-archives.yml
+++ b/.github/workflows/generate-archives.yml
@@ -14,7 +14,7 @@ jobs:
         batches: ${{ steps.read_batches.outputs.batches }}
       steps:
         - name: Checkout self
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
 
         - name: Read study-batches.txt
           id: read_batches
@@ -39,7 +39,7 @@ jobs:
 
       steps:
         - name: Checkout self
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
 
         - name: zip directory
           run: zip -r ${{ matrix.batch }}.zip ${{ matrix.batch }}


### PR DESCRIPTION
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
